### PR TITLE
Resolve configuration beyond getenv(), and stop requiring ext-posix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,59 @@ print $entry->getXML();
 ```
 
 
+## Configuration
+
+Settings are resolved in this order, first match winning:
+
+1. Overrides on the entry itself, via `withConfig()`
+2. Values given to `LogentryUtil::setDefaultConfig()`
+3. The process environment (`getenv()`)
+4. `$_ENV` and `$_SERVER`, which is where a `.env` file lands
+5. The `.env` shipped with this package
+
+### From the environment
+
+Nothing to do — the defaults in the bundled `src/.env` apply, and any
+environment variable of the same name overrides them.
+
+### Programmatically
+
+Useful when the host application already holds these settings and should not
+have to route them through the environment. A framework can do this once at
+boot:
+
+```php
+use Jlab\Eloglib\LogentryUtil;
+
+LogentryUtil::setDefaultConfig(array(
+    'SUBMIT_URL'    => 'https://logbooks.jlab.org/incoming',
+    'ELOGCERT_FILE' => '/etc/elog/elogcert',
+));
+```
+
+In Laravel, for example, from a service provider — which keeps the settings in
+`config/`, where they survive `php artisan config:cache`:
+
+```php
+LogentryUtil::setDefaultConfig([
+    'SUBMIT_URL'    => config('elog.submit_url'),
+    'ELOGCERT_FILE' => config('elog.cert_path'),
+]);
+```
+
+### Per entry
+
+To send a single entry somewhere else without disturbing global state:
+
+```php
+$entry = new Jlab\Eloglib\Logentry('Test', 'TLOG');
+$entry->withConfig(array('ELOGCERT_FILE' => '/path/to/another.pem'));
+```
+
+## Requirements
+
+`ext-curl`, `ext-dom` and `ext-libxml` are needed. `ext-posix` is used when
+present but is not required.
 
 ## API Reference
 Is available:  [API Reference](https://jeffersonlab.github.io/eloglib-php/) 

--- a/src/Logentry.php
+++ b/src/Logentry.php
@@ -162,6 +162,47 @@ class Logentry
      * @link https://logbooks.jlab.org/schema/Logentry.xsd
      * @link https://github.com/JeffersonLab/elog
      */
+    /**
+     * Configuration that applies to this entry alone.
+     *
+     * @var array
+     */
+    protected $configOverrides = array();
+
+    /**
+     * Supply configuration for this entry only.
+     *
+     * Takes precedence over LogentryUtil::setDefaultConfig() and over the
+     * environment, so a single entry can be sent somewhere else without
+     * disturbing global state:
+     *
+     *   $entry->withConfig(array('ELOGCERT_FILE' => '/path/to/other.pem'));
+     *
+     * @param array $settings
+     * @return Logentry
+     */
+    public function withConfig(array $settings)
+    {
+        $this->configOverrides = array_merge($this->configOverrides, $settings);
+
+        return $this;
+    }
+
+    /**
+     * Return this entry's override for a setting, or null when it has none.
+     *
+     * @param string $key
+     * @return mixed
+     */
+    public function configOverride($key)
+    {
+        if (isset($this->configOverrides[$key]) && $this->configOverrides[$key] !== '') {
+            return $this->configOverrides[$key];
+        }
+
+        return null;
+    }
+
     public function __construct()
     {
         $args = func_get_args();
@@ -274,8 +315,40 @@ class Logentry
      */
     protected function setDefaultAuthor()
     {
-        $os_user = posix_getpwuid(posix_getuid());
-        $this->setAuthor($os_user['name']);
+        $this->setAuthor(self::currentSystemUser());
+    }
+
+    /**
+     * The user running the current process.
+     *
+     * Uses ext-posix when it is available and falls back to core PHP otherwise,
+     * so that the extension is not required merely to construct an entry. It is
+     * routinely absent from container images.
+     *
+     * @return string
+     */
+    protected static function currentSystemUser()
+    {
+        if (function_exists('posix_getpwuid') && function_exists('posix_getuid')) {
+            $os_user = posix_getpwuid(posix_getuid());
+            if (is_array($os_user) && isset($os_user['name']) && $os_user['name'] !== '') {
+                return $os_user['name'];
+            }
+        }
+
+        $user = get_current_user();
+        if ($user !== '') {
+            return $user;
+        }
+
+        foreach (array('USER', 'USERNAME', 'LOGNAME') as $key) {
+            $value = LogentryUtil::config($key);
+            if ($value !== null && $value !== '') {
+                return $value;
+            }
+        }
+
+        return 'unknown';
     }
 
     /**
@@ -309,7 +382,19 @@ class Logentry
             } else {
                 $this->config = Dotenv::createImmutable($dir, $file);
             }
-            $this->config->load();
+            $loaded = $this->config->load();
+
+            // Dotenv writes to $_ENV and $_SERVER, never to the process
+            // environment, so a value already set with putenv() would still win
+            // over one loaded here. Promote an explicit overload into the
+            // configuration store, which outranks the environment, so that
+            // $overload keeps meaning what it says.
+            if ($overload && is_array($loaded)) {
+                LogentryUtil::setDefaultConfig(array_filter($loaded, function ($value) {
+                    return $value !== null && $value !== '';
+                }));
+            }
+
             // Throws if any required env variables are missing
             $this->config->required(array(
                 'LOG_ENTRY_SCHEMA_URL',
@@ -346,7 +431,7 @@ class Logentry
     {
         if (is_string($email)) {
             if (!stristr($email, '@')) {
-                $email .= getenv('EMAIL_DOMAIN');
+                $email .= LogentryUtil::config('EMAIL_DOMAIN', '', $this);
             }
             $addr = strtolower($email);
             $this->notifications[$addr] = $email;

--- a/src/LogentryUtil.php
+++ b/src/LogentryUtil.php
@@ -22,6 +22,87 @@ class LogentryUtil
      */
     public static $lastServerMsg;
 
+    /**
+     * Configuration supplied explicitly by the host application.
+     *
+     * @var array
+     */
+    protected static $config = array();
+
+    /**
+     * Supply configuration programmatically.
+     *
+     * Intended for host applications that already hold these settings and
+     * should not have to route them through the process environment. Values
+     * set here take precedence over the environment, and over the .env file
+     * bundled with this package.
+     *
+     *   LogentryUtil::setDefaultConfig(array(
+     *       'SUBMIT_URL'    => 'https://logbooks.jlab.org/incoming',
+     *       'ELOGCERT_FILE' => '/etc/elog/elogcert',
+     *   ));
+     *
+     * @param array $settings
+     * @return void
+     */
+    public static function setDefaultConfig(array $settings)
+    {
+        self::$config = array_merge(self::$config, $settings);
+    }
+
+    /**
+     * Discard configuration previously given to setDefaultConfig().
+     *
+     * @return void
+     */
+    public static function clearDefaultConfig()
+    {
+        self::$config = array();
+    }
+
+    /**
+     * Resolve a configuration value.
+     *
+     * Consulted in order: the entry's own overrides, configuration set with
+     * setDefaultConfig(), the process environment, then $_ENV and $_SERVER.
+     *
+     * Reading from $_ENV and $_SERVER matters: Dotenv writes there rather than
+     * to the process environment, so a value loaded from a .env file -- this
+     * package's own bundled defaults included -- is invisible to getenv() alone.
+     * It is also where frameworks such as Laravel put their configuration.
+     *
+     * @param string $key
+     * @param mixed $default returned when the key is set nowhere
+     * @param Logentry $entry consulted first, when given
+     * @return mixed
+     */
+    public static function config($key, $default = null, Logentry $entry = null)
+    {
+        if ($entry !== null) {
+            $override = $entry->configOverride($key);
+            if ($override !== null) {
+                return $override;
+            }
+        }
+
+        if (isset(self::$config[$key]) && self::$config[$key] !== '') {
+            return self::$config[$key];
+        }
+
+        $value = getenv($key);
+        if ($value !== false && $value !== '') {
+            return $value;
+        }
+
+        foreach (array($_ENV, $_SERVER) as $store) {
+            if (isset($store[$key]) && $store[$key] !== '') {
+                return $store[$key];
+            }
+        }
+
+        return $default;
+    }
+
 
     /**
      * Saves a Logentry object to an XML file
@@ -72,7 +153,7 @@ class LogentryUtil
 
     public static function queuePath()
     {
-        return getenv('DEFAULT_UNIX_QUEUE_PATH');
+        return self::config('DEFAULT_UNIX_QUEUE_PATH');
     }
 
     /**
@@ -82,7 +163,10 @@ class LogentryUtil
      */
     public static function queueFileName()
     {
-        $pid = posix_getpid();
+        // getmypid() is core PHP; posix_getpid() would make ext-posix a
+        // requirement of the direct submission path, which uses this name for
+        // its temp file.
+        $pid = getmypid();
         $hostname = trim(`hostname`);
         $date = date('Ymd');
         $time = date('His');
@@ -108,9 +192,9 @@ class LogentryUtil
 
         $FH = fopen($xmlFile, 'r');
         $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, self::submitUrl($xmlFile));
+        curl_setopt($ch, CURLOPT_URL, self::submitUrl($xmlFile, $entry));
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);  // cert is self-signed right now
-        curl_setopt($ch, CURLOPT_SSLCERT, self::certificateFile());
+        curl_setopt($ch, CURLOPT_SSLCERT, self::certificateFile($entry));
         curl_setopt($ch, CURLOPT_INFILE, $FH);
         curl_setopt($ch, CURLOPT_INFILESIZE, filesize($xmlFile));
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
@@ -144,14 +228,14 @@ class LogentryUtil
         return $filename;
     }
 
-    protected static function submitUrl($filename)
+    protected static function submitUrl($filename, Logentry $entry = null)
     {
-        return getenv('SUBMIT_URL') . '/' . urlencode(basename($filename));
+        return self::config('SUBMIT_URL', null, $entry) . '/' . urlencode(basename($filename));
     }
 
-    public static function certificateFile()
+    public static function certificateFile(Logentry $entry = null)
     {
-        $filename = getenv('ELOGCERT_FILE');
+        $filename = self::config('ELOGCERT_FILE', null, $entry);
         if (self::isSimpleFilename($filename)) {
             $filename = self::userHome() . DIRECTORY_SEPARATOR . $filename;
         }
@@ -178,8 +262,9 @@ class LogentryUtil
      */
     public static function userHome()
     {
-        // getenv('HOME') isn't set on Windows and generates a Notice.
-        $home = getenv('HOME');
+        // HOME is often absent from the process environment under a web SAPI
+        // even when $_SERVER carries it, and is not set at all on Windows.
+        $home = self::config('HOME');
         if (!empty($home)) {
             // home should never end with a trailing slash.
             $home = rtrim($home, '/');
@@ -280,7 +365,7 @@ class LogentryUtil
     {
 
         if ($schema == null) {
-            $schema = getenv('LOG_ENTRY_SCHEMA_URL');
+            $schema = self::config('LOG_ENTRY_SCHEMA_URL');
         }
 
         if (!is_readable($filename)) {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Tests;
+
+use Jlab\Eloglib\Logentry;
+use Jlab\Eloglib\LogentryUtil;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Configuration resolution.
+ *
+ * Deliberately free of setUp()/tearDown() and of assertions whose names have
+ * changed between PHPUnit majors, so these run unchanged on the version pinned
+ * in composer.json and on a current one.
+ */
+class ConfigTest extends TestCase
+{
+    /**
+     * The bundled .env is loaded through Dotenv, which writes to $_ENV rather
+     * than to the process environment. Reading with getenv() alone therefore
+     * misses the package's own defaults, leaving entries submitted to a bare
+     * path with no certificate.
+     */
+    function test_it_resolves_the_settings_shipped_with_the_package()
+    {
+        LogentryUtil::clearDefaultConfig();
+        new Logentry('test', 'TLOG');   // loads the bundled .env
+
+        $this->assertNotNull(LogentryUtil::config('SUBMIT_URL'));
+        $this->assertNotNull(LogentryUtil::config('LOG_ENTRY_SCHEMA_URL'));
+        $this->assertNotNull(LogentryUtil::config('ELOGCERT_FILE'));
+    }
+
+    function test_it_reads_from_the_process_environment()
+    {
+        LogentryUtil::clearDefaultConfig();
+        putenv('ELOGLIB_TEST_ONLY=from-putenv');
+
+        $this->assertEquals('from-putenv', LogentryUtil::config('ELOGLIB_TEST_ONLY'));
+
+        putenv('ELOGLIB_TEST_ONLY');
+    }
+
+    function test_it_reads_from_the_env_superglobal()
+    {
+        LogentryUtil::clearDefaultConfig();
+        $_ENV['ELOGLIB_TEST_ONLY'] = 'from-env';
+
+        $this->assertEquals('from-env', LogentryUtil::config('ELOGLIB_TEST_ONLY'));
+
+        unset($_ENV['ELOGLIB_TEST_ONLY']);
+    }
+
+    function test_it_reads_from_the_server_superglobal()
+    {
+        LogentryUtil::clearDefaultConfig();
+        $_SERVER['ELOGLIB_TEST_ONLY'] = 'from-server';
+
+        $this->assertEquals('from-server', LogentryUtil::config('ELOGLIB_TEST_ONLY'));
+
+        unset($_SERVER['ELOGLIB_TEST_ONLY']);
+    }
+
+    function test_it_returns_the_given_default_when_a_setting_is_absent()
+    {
+        LogentryUtil::clearDefaultConfig();
+
+        $this->assertEquals('fallback', LogentryUtil::config('ELOGLIB_NO_SUCH_SETTING', 'fallback'));
+        $this->assertNull(LogentryUtil::config('ELOGLIB_NO_SUCH_SETTING'));
+    }
+
+    function test_explicit_configuration_beats_the_environment()
+    {
+        LogentryUtil::clearDefaultConfig();
+        putenv('ELOGLIB_TEST_ONLY=from-putenv');
+        LogentryUtil::setDefaultConfig(array('ELOGLIB_TEST_ONLY' => 'explicit'));
+
+        $this->assertEquals('explicit', LogentryUtil::config('ELOGLIB_TEST_ONLY'));
+
+        putenv('ELOGLIB_TEST_ONLY');
+        LogentryUtil::clearDefaultConfig();
+    }
+
+    function test_explicit_configuration_can_be_cleared()
+    {
+        LogentryUtil::setDefaultConfig(array('ELOGLIB_TEST_ONLY' => 'explicit'));
+        LogentryUtil::clearDefaultConfig();
+
+        $this->assertNull(LogentryUtil::config('ELOGLIB_TEST_ONLY'));
+    }
+
+    function test_an_entry_overrides_the_explicit_configuration()
+    {
+        LogentryUtil::clearDefaultConfig();
+        LogentryUtil::setDefaultConfig(array('ELOGCERT_FILE' => '/etc/elog/default.pem'));
+
+        $entry = new Logentry('test', 'TLOG');
+        $entry->withConfig(array('ELOGCERT_FILE' => '/etc/elog/special.pem'));
+
+        $this->assertEquals('/etc/elog/special.pem', LogentryUtil::config('ELOGCERT_FILE', null, $entry));
+        $this->assertEquals('/etc/elog/default.pem', LogentryUtil::config('ELOGCERT_FILE'));
+
+        LogentryUtil::clearDefaultConfig();
+    }
+
+    function test_with_config_is_chainable()
+    {
+        $entry = new Logentry('test', 'TLOG');
+
+        $this->assertSame($entry, $entry->withConfig(array('SUBMIT_URL' => 'https://one.example')));
+    }
+
+    function test_certificate_file_honours_an_absolute_path_from_configuration()
+    {
+        LogentryUtil::clearDefaultConfig();
+        LogentryUtil::setDefaultConfig(array('ELOGCERT_FILE' => '/etc/elog/elogcert'));
+
+        $this->assertEquals('/etc/elog/elogcert', LogentryUtil::certificateFile());
+
+        LogentryUtil::clearDefaultConfig();
+    }
+
+    function test_certificate_file_honours_a_per_entry_override()
+    {
+        LogentryUtil::clearDefaultConfig();
+        LogentryUtil::setDefaultConfig(array('ELOGCERT_FILE' => '/etc/elog/elogcert'));
+
+        $entry = new Logentry('test', 'TLOG');
+        $entry->withConfig(array('ELOGCERT_FILE' => '/tmp/other.pem'));
+
+        $this->assertEquals('/tmp/other.pem', LogentryUtil::certificateFile($entry));
+
+        LogentryUtil::clearDefaultConfig();
+    }
+
+    /**
+     * ext-posix is routinely absent from container images, and was previously
+     * needed merely to name the temp file that direct submission writes.
+     */
+    function test_queue_file_names_do_not_require_ext_posix()
+    {
+        $name = LogentryUtil::queueFileName();
+
+        $this->assertTrue(substr($name, -4) === '.xml', 'queue file should be XML');
+        $this->assertTrue(strpos($name, (string) getmypid()) !== false, 'name should carry the pid');
+    }
+
+    function test_the_default_author_is_set_without_ext_posix()
+    {
+        $entry = new Logentry('test', 'TLOG');
+
+        $this->assertNotEmpty($entry->author->username);
+    }
+}

--- a/tests/LogentryTest.php
+++ b/tests/LogentryTest.php
@@ -30,9 +30,15 @@ class LogentryTest extends TestCase
 
     function test_it_sets_default_author()
     {
-        $os_user = posix_getpwuid(posix_getuid());
         $entry = new Logentry('test', 'TLOG');
-        $this->assertEquals($os_user['name'], $entry->author->username);
+
+        if (function_exists('posix_getpwuid') && function_exists('posix_getuid')) {
+            $os_user = posix_getpwuid(posix_getuid());
+            $this->assertEquals($os_user['name'], $entry->author->username);
+        } else {
+            // Without ext-posix the author still has to be someone.
+            $this->assertNotEmpty($entry->author->username);
+        }
     }
 
     function test_it_sets_logbooks_from_array()
@@ -49,11 +55,14 @@ class LogentryTest extends TestCase
 
     function test_it_sets_config()
     {
-        // The following code/assertions depend on the default .env file in the source directory
-        // after loading, its contents should be accessible via getenv()
+        // The following assertions depend on the default .env file in the source
+        // directory. Dotenv writes it to $_ENV rather than the process
+        // environment, so it is reached through LogentryUtil::config() rather
+        // than getenv() alone.
+        LogentryUtil::clearDefaultConfig();
         $entry = new Logentry('test', 'TLOG');
-        $this->assertEquals('http://logbooks.jlab.org/schema/Logentry.xsd', getenv('LOG_ENTRY_SCHEMA_URL'));
-        $this->assertEquals('https://logbooks.jlab.org/incoming', getenv('SUBMIT_URL'));
+        $this->assertEquals('http://logbooks.jlab.org/schema/Logentry.xsd', LogentryUtil::config('LOG_ENTRY_SCHEMA_URL'));
+        $this->assertEquals('https://logbooks.jlab.org/incoming', LogentryUtil::config('SUBMIT_URL'));
     }
 
     function test_it_throws_on_bad_config_file()
@@ -68,12 +77,16 @@ class LogentryTest extends TestCase
     function test_it_overrides_config()
     {
         // The default initialization should not override existing env variables
+        LogentryUtil::clearDefaultConfig();
         putenv('SUBMIT_URL=foobar');
         $entry = new Logentry('test', 'TLOG');
-        $this->assertEquals('foobar', getenv('SUBMIT_URL'));
+        $this->assertEquals('foobar', LogentryUtil::config('SUBMIT_URL'));
         // The third param below forces config file to override existing env
         $entry->setConfig(__DIR__ . '/../src', '.env', true);
-        $this->assertEquals('https://logbooks.jlab.org/incoming', getenv('SUBMIT_URL'));
+        $this->assertEquals('https://logbooks.jlab.org/incoming', LogentryUtil::config('SUBMIT_URL'));
+
+        putenv('SUBMIT_URL');
+        LogentryUtil::clearDefaultConfig();
     }
 
     function test_it_adds_entrymaker()


### PR DESCRIPTION
Settings were written with Dotenv but read with getenv(). Since phpdotenv 5 those are different stores -- DEFAULT_ADAPTERS is ServerConstAdapter and EnvConstAdapter, with PutenvAdapter no longer among them -- so the .env shipped with this package lands in $_ENV and never reaches the code that reads it. Entries are then submitted to a bare path with no certificate. composer.json allows "^4.0|^5.0", so which behaviour you get depends on which phpdotenv resolved.

test_it_sets_config already asserted this contract and fails on master under phpdotenv 5. It is updated to read through the resolver rather than deleted.

LogentryUtil::config() now consults, in order: the entry's own overrides, configuration given to setDefaultConfig(), getenv(), then $_ENV and $_SERVER. Every call site goes through it, so existing setups keep working while the bundled defaults finally apply.

setDefaultConfig() and withConfig() let a host application supply settings directly. Frameworks tend to hold configuration already and should not have to smuggle it through the environment -- in Laravel especially, where `php artisan config:cache` stops .env being loaded at all, so anything read from it at runtime silently disappears in production.

setConfig(..., $overload = true) keeps its documented meaning by promoting the loaded values into that store; Dotenv's mutable write also only reaches $_ENV, so a value already set with putenv() would otherwise still win.

ext-posix is no longer required. getmypid() replaces posix_getpid(), which mattered because queueFileName() names the temp file used by direct submission, so the extension was needed even when never queueing. The default author falls back to get_current_user(). The extension is routinely absent from container images.

Two pre-existing errors remain on PHP 8 -- test_gets_xml_minimal and test_gets_xml_complex call DOMDocument::loadXML() statically -- and are left alone as unrelated to this change.